### PR TITLE
Add example pages showcasing markdown features

### DIFF
--- a/docs/examples/admonitions.md
+++ b/docs/examples/admonitions.md
@@ -1,0 +1,10 @@
+# Admonitions
+
+!!! note
+    This is a simple note.
+
+!!! warning
+    Be careful with warnings!
+
+??? tip "Expandable"
+    Details can be hidden inside collapsible tips.

--- a/docs/examples/code-highlighting.md
+++ b/docs/examples/code-highlighting.md
@@ -1,0 +1,12 @@
+# Code Highlighting
+
+```python
+def greet(name):
+    return f"Hello, {name}!"
+```
+
+```bash
+echo "Hello from the shell"
+```
+
+Inline code like `print("hi")` is also supported.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,8 @@
+# Feature Examples
+
+Explore some of the cool features supported by this site:
+
+- [Admonitions](admonitions.md)
+- [Code Highlighting](code-highlighting.md)
+- [Math Rendering](math.md)
+- [Interactive Elements](interactive-elements.md)

--- a/docs/examples/interactive-elements.md
+++ b/docs/examples/interactive-elements.md
@@ -1,0 +1,33 @@
+# Interactive Elements
+
+## Task List
+
+- [x] Write docs
+- [ ] Deploy site
+
+## Progress Bar
+
+[=70%]
+
+## Tabs
+
+=== "Python"
+
+    ```python
+    print("Tabs are great!")
+    ```
+
+=== "JavaScript"
+
+    ```javascript
+    console.log("Tabbed code blocks");
+    ```
+
+## Details
+
+??? example "Click to expand"
+    Hidden content inside a collapsible block.
+
+## Emoji and Keys
+
+:smile: Press ++Ctrl+Shift+P++ to open the command palette.

--- a/docs/examples/math.md
+++ b/docs/examples/math.md
@@ -1,0 +1,9 @@
+# Math Rendering
+
+Inline math: $E=mc^2$
+
+Block math:
+
+$$
+\int_0^1 x^2 dx = \frac{1}{3}
+$$

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,3 +122,7 @@ You can now use the integrated terminal to run Makefile commands or use Docker a
 - [How to Debug Like a Pro](posts/debug-like-a-pro.md)
 - [Top 5 Python Tricks](posts/python-tricks.md)
 - [Why Markdown is Awesome](posts/markdown-awesome.md)
+
+## Explore Feature Examples
+
+Discover more Markdown capabilities in the [examples](examples/index.md) section.


### PR DESCRIPTION
## Summary
- add examples highlighting admonitions, code blocks, math, and interactive elements
- link homepage to new feature examples

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d2252a6c48327b9e39e08f305df94